### PR TITLE
Added a 2 second delay after closing dialog

### DIFF
--- a/lib/features/scanner/scanner_controller.dart
+++ b/lib/features/scanner/scanner_controller.dart
@@ -15,6 +15,7 @@ class ScannerController {
     onScan(code);
   }
 
+  // Resets timer
   void reset() {
     _hasScanned = false;
   }

--- a/lib/features/scanner/scanner_page.dart
+++ b/lib/features/scanner/scanner_page.dart
@@ -25,7 +25,9 @@ class _BarcodeScannerPageState extends State<BarcodeScannerPage>{
                     TextButton(
                         onPressed: (){
                             Navigator.pop(context);
-                            _scannerController.reset(); // Re-enable scanning
+                            Future.delayed(const Duration(seconds: 2), (){
+                                _scannerController.reset(); // Re-enable scanning
+                            });
                         },
                         child: const Text('OK'))
                 ],


### PR DESCRIPTION
The scanner now waits 2 seconds after the user closes the barcode info dialog before re-enabling scanning. This prevents immediate rescans of the same item when the barcode is still in view.